### PR TITLE
Add 'cannot run on windows' to FPGA tools tutorials

### DIFF
--- a/DirectProgramming/DPC++FPGA/Tutorials/Tools/dynamic_profiler/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Tools/dynamic_profiler/CMakeLists.txt
@@ -12,6 +12,6 @@ if(UNIX)
     add_subdirectory (src)
 else() # Windows
     # This code sample does not currently support windows
-    message(STATUS "This code sample is cannot be configured to run on Windows!\
+    message(FATAL_ERROR "Error: This code sample cannot be configured to run on Windows!\
                     \nPlease look over the README for information on using this feature on windows.")
 endif()

--- a/DirectProgramming/DPC++FPGA/Tutorials/Tools/dynamic_profiler/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Tools/dynamic_profiler/CMakeLists.txt
@@ -1,18 +1,17 @@
 if(UNIX)
     # Direct CMake to use dpcpp rather than the default C++ compiler/linker
     set(CMAKE_CXX_COMPILER dpcpp)
+    cmake_minimum_required (VERSION 3.4)
+
+    project(DynamicProfiler CXX)
+
+    set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+
+    add_subdirectory (src)
 else() # Windows
     # This code sample does not currently support windows
     message(STATUS "This code sample is cannot be configured to run on Windows!\
                     \nPlease look over the README for information on using this feature on windows.")
 endif()
-
-cmake_minimum_required (VERSION 3.4)
-
-project(DynamicProfiler CXX)
-
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
-
-add_subdirectory (src)

--- a/DirectProgramming/DPC++FPGA/Tutorials/Tools/dynamic_profiler/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Tools/dynamic_profiler/CMakeLists.txt
@@ -2,11 +2,9 @@ if(UNIX)
     # Direct CMake to use dpcpp rather than the default C++ compiler/linker
     set(CMAKE_CXX_COMPILER dpcpp)
 else() # Windows
-    # Force CMake to use dpcpp rather than the default C++ compiler/linker 
-    # (needed on Windows only)
-    include (CMakeForceCompiler)
-    CMAKE_FORCE_CXX_COMPILER (dpcpp IntelDPCPP)
-    include (Platform/Windows-Clang)
+    # This code sample does not currently support windows
+    message(STATUS "This code sample is cannot be configured to run on Windows!\
+                    \nPlease look over the README for information on using this feature on windows.")
 endif()
 
 cmake_minimum_required (VERSION 3.4)

--- a/DirectProgramming/DPC++FPGA/Tutorials/Tools/system_profiling/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Tools/system_profiling/CMakeLists.txt
@@ -1,18 +1,17 @@
 if(UNIX)
     # Direct CMake to use dpcpp rather than the default C++ compiler/linker
     set(CMAKE_CXX_COMPILER dpcpp)
+    cmake_minimum_required (VERSION 3.4)
+    
+    project(SystemProfiling CXX)
+    
+    set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+    
+    add_subdirectory (src)
 else() # Windows
     # This code sample does not currently support windows
     message(STATUS "This code sample is cannot be configured to run on Windows!\
                     \nPlease look over the README for information on using this feature on windows.")
 endif()
-
-cmake_minimum_required (VERSION 3.4)
-
-project(SystemProfiling CXX)
-
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
-
-add_subdirectory (src)

--- a/DirectProgramming/DPC++FPGA/Tutorials/Tools/system_profiling/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Tools/system_profiling/CMakeLists.txt
@@ -12,6 +12,6 @@ if(UNIX)
     add_subdirectory (src)
 else() # Windows
     # This code sample does not currently support windows
-    message(STATUS "This code sample is cannot be configured to run on Windows!\
+    message(FATAL_ERROR "Error: This code sample cannot be configured to run on Windows!\
                     \nPlease look over the README for information on using this feature on windows.")
 endif()

--- a/DirectProgramming/DPC++FPGA/Tutorials/Tools/system_profiling/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Tools/system_profiling/CMakeLists.txt
@@ -2,11 +2,9 @@ if(UNIX)
     # Direct CMake to use dpcpp rather than the default C++ compiler/linker
     set(CMAKE_CXX_COMPILER dpcpp)
 else() # Windows
-    # Force CMake to use dpcpp rather than the default C++ compiler/linker 
-    # (needed on Windows only)
-    include (CMakeForceCompiler)
-    CMAKE_FORCE_CXX_COMPILER (dpcpp IntelDPCPP)
-    include (Platform/Windows-Clang)
+    # This code sample does not currently support windows
+    message(STATUS "This code sample is cannot be configured to run on Windows!\
+                    \nPlease look over the README for information on using this feature on windows.")
 endif()
 
 cmake_minimum_required (VERSION 3.4)


### PR DESCRIPTION
# Existing Sample Changes
## Description

This change adds a warning to two code samples that do not support running on Windows, and prevents CMake from running any further. This is to make sure users who didn't notice the code sample doesn't support windows will not accidentally try running it only to hit issues further in. 

Fixes Issue# 

## External Dependencies

N/A

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
